### PR TITLE
Relax version constraint to include support for PHP 7.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require" : {
-    "php" : "~5.5.0|~5.6.0|~7.0.0",
+    "php" : "~5.5.0|~5.6.0|^7.0.0",
     "magento/magento-composer-installer" : "*",
     "composer/installers" : "~1.0",
     "magento/framework": "^100.1||^101.0",


### PR DESCRIPTION
Currently unable to include this module via composer install/update since we're running PHP 7.1.x