### PR TITLE
Update Response.php

### DIFF
--- a/Controller/Payment/Response.php
+++ b/Controller/Payment/Response.php
@@ -170,6 +170,8 @@ class Response extends Action
             $this->logger->debug(['process error ' => $e->getTraceAsString()]);
             $this->messageManager->addExceptionMessage($e, $e->getMessage());
 
+            $order = $this->checkoutSession->getLastRealOrder();
+            
             if (!$order->getId()) {
                 $this->laybuy->laybuyCancel($token);
             }


### PR DESCRIPTION
Fix the "Undefined variable: order" error caused when a Laybuy transaction fails.