### PR TITLE
Add checkout terms and conditions to laybuy.html

### DIFF
--- a/view/frontend/web/template/payment/laybuy.html
+++ b/view/frontend/web/template/payment/laybuy.html
@@ -24,6 +24,12 @@
             <!-- ko template: getTemplate() --><!-- /ko -->
             <!--/ko-->
         </div>
+        <div class="checkout-agreements-block">
+            <!-- ko foreach: $parent.getRegion('before-place-order') -->
+            <!-- ko template: getTemplate() -->
+            <!-- /ko -->
+            <!--/ko-->
+        </div>
         <div class="actions-toolbar">
             <div class="primary">
                 <button class="action primary checkout"


### PR DESCRIPTION
This is required if you enable Terms and Conditions in Magento 2 and show it on checkout, the method will not be useable.