### PR TITLE
Fixes the insertion of the Transaction Id on Invoice

### DIFF
--- a/Controller/Payment/Response.php
+++ b/Controller/Payment/Response.php
@@ -86,6 +86,8 @@ class Response extends Action
 
                         if ($orderId && $order) {
 
+                            $txnId = $laybuyOrderId . '_' . $token;
+                            $this->laybuy->addTransactionId($order,$txnId);
                             $this->laybuy->sendOrderEmail($order);
 
                             $this->logger->debug([

--- a/Model/Laybuy.php
+++ b/Model/Laybuy.php
@@ -555,6 +555,32 @@ class Laybuy extends \Magento\Payment\Model\Method\AbstractMethod
 
         return true;
     }
+
+    /**
+     * @param \Magento\Sales\Model\Order $order
+     * @param $txnId
+     * @return bool
+     */
+    public function addTransactionId(\Magento\Sales\Model\Order $order,$txnId)
+    {
+        if(!$order->hasInvoices())
+        {
+            return false;
+        }
+
+        foreach($order->getInvoiceCollection() as $invoice)
+        {
+            $invoice->setTransactionId($txnId);
+            $invoice->save();
+
+             $this->logger->debug([
+                'Invoice Id ' => $invoice->getId(),
+                'Transaction Id ' => $invoice->getTransactionId()
+            ]);
+        }
+
+        return true;
+    }
 }
 
 

--- a/Model/Laybuy.php
+++ b/Model/Laybuy.php
@@ -385,11 +385,11 @@ class Laybuy extends \Magento\Payment\Model\Method\AbstractMethod
 
     /**
      * @param \Magento\Sales\Model\Order $order
-     * @param $orderId
+     * @param $txnId
      * @throws \Exception
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function createInvoiceAndUpdateOrder(\Magento\Sales\Model\Order $order, $orderId, $laybuyOrderId)
+    public function createInvoiceAndUpdateOrder(\Magento\Sales\Model\Order $order, $txnId, $laybuyOrderId)
     {
 
         $order->setState(\Magento\Sales\Model\Order::STATE_PROCESSING)
@@ -399,6 +399,7 @@ class Laybuy extends \Magento\Payment\Model\Method\AbstractMethod
 
         $invoice = $this->invoiceService->prepareInvoice($order);
         $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
+        $invoice->setTransactionId($txnId);
         $invoice->register();
 
         /** @var \Magento\Framework\DB\Transaction $transaction */


### PR DESCRIPTION
The Invoice is not saving any transaction Id once its captured and created.