### PR TITLE
Send guest email as a POST parameter

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/laybuy.js
+++ b/view/frontend/web/js/view/payment/method-renderer/laybuy.js
@@ -64,22 +64,16 @@ define([
         },
 
         getRedirectUrl: function() {
-            var laybuyUrl, redirectUrl, self = this;
-
-            /**
-             * Checkout for guest and registered customer.
-             */
-            if (!customer.isLoggedIn()) {
-                laybuyUrl = window.checkoutConfig.payment['laybuy_payment'].laybuyProcessUrl + 'guest-email/' + quote.guestEmail;
-            } else {
-                laybuyUrl = window.checkoutConfig.payment['laybuy_payment'].laybuyProcessUrl;
-            }
+            var redirectUrl, self = this;
 
             $.ajax({
-                url: laybuyUrl,
+                url: window.checkoutConfig.payment['laybuy_payment'].laybuyProcessUrl,
                 method: 'post',
                 cache: false,
-                async: false
+                async: false,
+                data: {
+                    "guest-email": quote.guestEmail
+                }
             }).success(function(data) {
                 if (data.success) {
                     redirectUrl = data.redirect_url;


### PR DESCRIPTION
The current implementation means that emails such as 'test+1@example.com' will be saved in the quote table's customer_email column as 'test 1@example.com'. This can break later calls to validate the quote (and obviously means the customer won't receive any further communication). Sending the guest-email parameter as a POST parameter addresses this issue.

For a logged in customer, the parameter will be an empty string and interpreted in Model/Laybuy.php:276 as false (the correct and existing behaviour).