### PR TITLE
Update code for compatibility with Magento 2.4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "magento/module-sales": "103.0.*"
   },
   "type" : "magento2-module",
-  "version" : "0.1.3",
+  "version" : "0.1.4",
   "license" : [
     "OSL-3.0",
     "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-	<module name="Laybuy_Laybuy" setup_version="0.1.3">
+	<module name="Laybuy_Laybuy" setup_version="0.1.4">
 		<sequence>
 			<module name="Magento_GraphQl"/>
 			<module name="Magento_Sales" />

--- a/view/frontend/web/js/view/payment/method-renderer/laybuy.js
+++ b/view/frontend/web/js/view/payment/method-renderer/laybuy.js
@@ -74,12 +74,12 @@ define([
                 data: {
                     "guest-email": quote.guestEmail
                 }
-            }).success(function(data) {
+            }).done(function(data) {
                 if (data.success) {
                     redirectUrl = data.redirect_url;
 
                     if (window.checkoutConfig.payment['laybuy_payment'].paymentAction == 'authorize_capture') {
-                        setBillingAddressAction(globalMessageList).success(function() {
+                        setBillingAddressAction(globalMessageList).done(function() {
                             $.mage.redirect(redirectUrl);
                         })
                     } else {


### PR DESCRIPTION
For Magento 2.4.6 version,  "Zend framework (ZF1) components that have reached end of life have been removed from the codebase." https://experienceleague.adobe.com/docs/commerce-operations/release/notes/adobe-commerce/2-4-6.html
Laybuy module uses ZF1 to request => it will throw an error.
Currently, I tested the update code with fresh Magento 2.4.5 & 2.4.6, and it works correctly (create/cancel/refund orders).